### PR TITLE
Add background color option to CLI

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,6 +15,7 @@ module.exports = async (argv) => {
     .option('-o, --output <path>', 'relative path to store output media (image, image pattern, gif, or mp4)', 'out.png')
     .option('-w, --width <number>', 'optional output width', (s) => parseInt(s))
     .option('-h, --height <number>', 'optional output height', (s) => parseInt(s))
+    .option('-b, --background <css-color-value>', 'optional output background color', 'transparent')
     .option('-q, --quiet', 'disable output progress', false)
 
   program.on('--help', () => {
@@ -38,7 +39,10 @@ module.exports = async (argv) => {
     output: program.output,
     width: program.width,
     height: program.height,
-    quiet: program.quiet
+    quiet: program.quiet,
+    style: {
+      background: program.background
+    }
   }
 
   if (program.args.length > 0) {

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,8 @@ Options:
   -o, --output <path>    relative path to store output media (image, image pattern, gif, or mp4) (default: "out.png")
   -w, --width <number>   optional output width
   -h, --height <number>  optional output height
+  -b, --background <css-color-value>
+                         optional output background color (default: "transparent")
   -q, --quiet            disable output progress
   -V, --version          output the version number
   -h, --help             output usage information


### PR DESCRIPTION
Allows setting a background-colour instead of transparent (PNG/GIF) or default (white for JPEG, black for MP4).