### PR TITLE
Add Custom Puppeteer CLI Arg

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,11 @@ const renderLottie = require('puppeteer-lottie')
 const { version } = require('../package')
 
 module.exports = async (argv) => {
+
+  function commaSeparatedList(value, dummyPrevious) {
+    return value.split(',');
+  }
+
   program
     .name('puppeteer-lottie')
     .version(version)
@@ -16,6 +21,7 @@ module.exports = async (argv) => {
     .option('-w, --width <number>', 'optional output width', (s) => parseInt(s))
     .option('-h, --height <number>', 'optional output height', (s) => parseInt(s))
     .option('-b, --background <css-color-value>', 'optional output background color', 'transparent')
+    .option('-p, --puppeteerOptions <cmd-options>', 'optional puppeteer command line arguments', commaSeparatedList)
     .option('-q, --quiet', 'disable output progress', false)
 
   program.on('--help', () => {
@@ -40,6 +46,7 @@ module.exports = async (argv) => {
     width: program.width,
     height: program.height,
     quiet: program.quiet,
+    puppeteerOptions: program.puppeteerOptions ? {args: program.puppeteerOptions} : {},
     style: {
       background: program.background
     }


### PR DESCRIPTION
Fixes https://github.com/transitive-bullshit/puppeteer-lottie-cli/issues/3

Unsure if I should add a hard example to the documentation but
`$ puppeteer-lottie -i fixtures/bodymovin.json -o out.mp4` ->
`$ puppeteer-lottie -i fixtures/bodymovin.json -o out.mp4 -p "--no-sandbox,--disable-setuid-sandbox"`
is the change in syntax
